### PR TITLE
Make macgyver support yaml encrypt/decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Available Commands:
 
 Flags:
       --AWScryptoKeyID string   the cryptoKeyID of AWS
-      --AWSlocationID string    the cryptoKeyID of AWS
+      --AWSlocationID string    the locationID of AWS
       --AWSprofileName string   the profile name used for AWS authentication
       --GCPcryptoKeyID string   the cryptoKeyID of GCP
       --GCPkeyRingID string     the keyRingID of GCP

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Flags:
       --config string           config file (default is $HOME/.macgyver.yaml)
       --cryptoProvider string   Which type you using encrypto and encryto
       --flags string            the sort code of the contact account
+      --file string              absolute filepath for a yaml
   -h, --help                    help for macgyver
-      --keysType string         Which input type you using for encrypto and encryto (default "text")
+      --keysType string         Which input type you using for encrypto and encryto (default "text") (text, file)
       --oAuthLocation string    location of the JSON key credentials file. If empty then use the Google Application Defaults.
       --secretTag string        the prefix of secret (default "secret_tag")
 
@@ -331,6 +332,74 @@ Output
 10.10.10.10
 root
 password
+```
+
+---
+
+---
+
+### Using Base64 with file type (yaml)
+
+Currently, file type only support yaml file. And because of some limitation and easy usages, macgyver won't keep anchor and reference in yaml after parsing.
+
+It only supports encrypt string type item, so if you want to encrypt other types (e.g. int, float, bool) you need to quote them.
+
+
+#### Encrypt and Decrypt
+```
+
+echo "test: abc
+test2: 
+    abc: cde
+    def: 1
+    ghi: 
+        - abc
+        - true" > test2.yaml
+
+cat test2.yaml
+
+>> 
+test: abc
+test2: 
+    abc: cde
+    def: 1
+    ghi: 
+        - abc
+        - true
+
+
+
+macgyver encrypt \
+--cryptoProvider=base64 \
+--keysType=file \
+--file=test2.yaml
+
+cat test2.yaml
+>>
+test: <SECRET_TAG>YWJj</SECRET_TAG>
+test2:
+    abc: <SECRET_TAG>Y2Rl</SECRET_TAG>
+    def: 1
+    ghi:
+        - <SECRET_TAG>YWJj</SECRET_TAG>
+        - true
+
+
+macgyver decrypt \
+--cryptoProvider=base64 \
+--keysType=file \
+--file=test2.yaml
+
+>> 
+test: abc
+test2:
+    abc: cde
+    def: 1
+    ghi:
+        - abc
+        - true
+
+
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Available Commands:
 
 Flags:
       --AWScryptoKeyID string   the cryptoKeyID of AWS
-      --AWSlocationID string    the locationID of AWS
+      --AWSlocationID string    the cryptoKeyID of AWS
       --AWSprofileName string   the profile name used for AWS authentication
       --GCPcryptoKeyID string   the cryptoKeyID of GCP
       --GCPkeyRingID string     the keyRingID of GCP
@@ -40,10 +40,10 @@ Flags:
       --GCPprojectID string     the projectID of GCP
       --config string           config file (default is $HOME/.macgyver.yaml)
       --cryptoProvider string   Which type you using encrypto and encryto
+      --file string             absolute filepath for a yaml you want to decrypt/encrypt
       --flags string            the sort code of the contact account
-      --file string              absolute filepath for a yaml
   -h, --help                    help for macgyver
-      --keysType string         Which input type you using for encrypto and encryto (default "text") (text, file)
+      --keysType string         Which input type you using for encrypto and encryto (e.g. text, file and env) (default "text")
       --oAuthLocation string    location of the JSON key credentials file. If empty then use the Google Application Defaults.
       --secretTag string        the prefix of secret (default "secret_tag")
 

--- a/cmd/crypto/base64.go
+++ b/cmd/crypto/base64.go
@@ -27,5 +27,9 @@ func (im *base64) Decrypt(encryptText []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// To remove base64 padding 0
+	for decoded[len(decoded)-1] == 0 {
+		decoded = decoded[:len(decoded)-1]
+	}
 	return decoded, nil
 }

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -42,32 +42,37 @@ func init() {
 
 func decrypt(cmd *cobra.Command, args []string) {
 	crypto.Init(cryptoProvider)
-	inputs := map[keys.Type][]string{
-		keys.TypeText: strings.Split(flags, " "),
-		keys.TypeEnv:  os.Environ(),
-	}
 	k, err := keys.Get(keysType)
 	if err != nil {
 		log.Panic(err)
 	}
-	keyFlags := k.Import(inputs[keysType], SecretTag)
 
-	// Decrypt all secrets that are encrypted of each key
-	p := crypto.Providers[cryptoProvider]
-	for _, keyFlag := range keyFlags {
-		for _, s := range keyFlag.Secrets {
-			if !s.IsEncrypted {
-				continue
+	// use file, flags or nev
+	switch keysType {
+	case keys.TypeText:
+		keyFlags := k.Import(strings.Split(flags, " "), SecretTag)
+		// Decrypt all secrets that are encrypted of each key
+		p := crypto.Providers[cryptoProvider]
+		for _, keyFlag := range keyFlags {
+			for _, s := range keyFlag.Secrets {
+				if !s.IsEncrypted {
+					continue
+				}
+				decryptText, err := p.Decrypt([]byte(s.Text))
+				if err != nil {
+					log.Panic(err)
+				}
+				s.Text = string(decryptText)
+				s.IsEncrypted = false
 			}
-			decryptText, err := p.Decrypt([]byte(s.Text))
-			if err != nil {
-				log.Panic(err)
-			}
-			s.Text = string(decryptText)
-			s.IsEncrypted = false
 		}
+		// Convert decrypted keys back to string
+		k.Export(keyFlags, SecretTag, os.Stdout)
+	case keys.TypeFile:
+		log.Panic("file type is not ready")
+	case keys.TypeEnv:
+		log.Panic("env type is not ready")
+	default:
+		log.Panicf("keysType does not support %s", keysType)
 	}
-
-	// Convert decrypted keys back to string
-	k.Export(keyFlags, SecretTag, os.Stdout)
 }

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -46,11 +46,15 @@ func decrypt(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Panic(err)
 	}
+	inputs := map[keys.Type][]string{
+		keys.TypeText: strings.Split(flags, " "),
+		keys.TypeEnv:  os.Environ(),
+	}
 
 	// use file, flags or nev
 	switch keysType {
-	case keys.TypeText:
-		keyFlags := k.Import(strings.Split(flags, " "), SecretTag)
+	case keys.TypeText, keys.TypeEnv:
+		keyFlags := k.Import(inputs[keysType], SecretTag)
 		// Decrypt all secrets that are encrypted of each key
 		p := crypto.Providers[cryptoProvider]
 		for _, keyFlag := range keyFlags {
@@ -74,8 +78,6 @@ func decrypt(cmd *cobra.Command, args []string) {
 		if err := k.ReplaceOriginFile(file, values); err != nil {
 			log.Panic(err)
 		}
-	case keys.TypeEnv:
-		log.Panic("env type is not ready")
 	default:
 		log.Panicf("keysType does not support %s", keysType)
 	}

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -69,7 +69,11 @@ func decrypt(cmd *cobra.Command, args []string) {
 		// Convert decrypted keys back to string
 		k.Export(keyFlags, SecretTag, os.Stdout)
 	case keys.TypeFile:
-		log.Panic("file type is not ready")
+		p := crypto.Providers[cryptoProvider]
+		values := k.Decrypt(file, SecretTag, p)
+		if err := k.ReplaceOriginFile(file, values); err != nil {
+			log.Panic(err)
+		}
 	case keys.TypeEnv:
 		log.Panic("env type is not ready")
 	default:

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -42,19 +42,20 @@ func init() {
 
 func decrypt(cmd *cobra.Command, args []string) {
 	crypto.Init(cryptoProvider)
-	k, err := keys.Get(keysType)
-	if err != nil {
-		log.Panic(err)
-	}
 	inputs := map[keys.Type][]string{
 		keys.TypeText: strings.Split(flags, " "),
 		keys.TypeEnv:  os.Environ(),
+	}
+	k, err := keys.Get(keysType)
+	if err != nil {
+		log.Panic(err)
 	}
 
 	// use file, flags or nev
 	switch keysType {
 	case keys.TypeText, keys.TypeEnv:
 		keyFlags := k.Import(inputs[keysType], SecretTag)
+
 		// Decrypt all secrets that are encrypted of each key
 		p := crypto.Providers[cryptoProvider]
 		for _, keyFlag := range keyFlags {

--- a/cmd/decrypt_test.go
+++ b/cmd/decrypt_test.go
@@ -32,7 +32,7 @@ func (s *decryptTestSuite) TestDecrypt() {
 		decrypt(encryptCmd, []string{})
 		_ = fakeStdout.Close()
 		newOutBytes, _ := ioutil.ReadAll(r)
-		s.Equal([]byte("-test=test\x00\x00\n"), newOutBytes)
+		s.Equal([]byte("-test=test\n"), newOutBytes)
 	})
 }
 

--- a/cmd/decrypt_test.go
+++ b/cmd/decrypt_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/17media/macgyver/cmd/keys"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type decryptTestSuite struct {
+	suite.Suite
+}
+
+func (s *decryptTestSuite) SetupSuite()    {}
+func (s *decryptTestSuite) TearDownSuite() {}
+func (s *decryptTestSuite) SetupTest()     {}
+func (s *decryptTestSuite) TearDownTest()  {}
+
+func (s *decryptTestSuite) TestDecrypt() {
+	s.Run("decrypt text base64", func() {
+		realStdout := os.Stdout
+		defer func() { os.Stdout = realStdout }()
+		r, fakeStdout, _ := os.Pipe()
+
+		cryptoProvider = "base64"
+		keysType = keys.TypeText
+		flags = "-test=<SECRET_TAG>dGVzdA==</SECRET_TAG>"
+		os.Stdout = fakeStdout
+
+		decrypt(encryptCmd, []string{})
+		_ = fakeStdout.Close()
+		newOutBytes, _ := ioutil.ReadAll(r)
+		s.Equal([]byte("-test=test\x00\x00\n"), newOutBytes)
+	})
+}
+
+func TestDecryptSuite(t *testing.T) {
+	suite.Run(t, new(decryptTestSuite))
+}

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -72,7 +72,11 @@ func encrypt(cmd *cobra.Command, args []string) {
 		// Convert decrypted keys back to string
 		k.Export(keyFlags, SecretTag, os.Stdout)
 	case keys.TypeFile:
-		log.Panic("file type is not ready")
+		p := crypto.Providers[cryptoProvider]
+		values := k.Encrypt(file, SecretTag, p)
+		if err := k.ReplaceOriginFile(file, values); err != nil {
+			log.Panic(err)
+		}
 	case keys.TypeEnv:
 		log.Panic("env type is not ready")
 	default:

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -45,19 +45,20 @@ func init() {
 
 func encrypt(cmd *cobra.Command, args []string) {
 	crypto.Init(cryptoProvider)
-	k, err := keys.Get(keysType)
-	if err != nil {
-		log.Panic(err)
-	}
 	inputs := map[keys.Type][]string{
 		keys.TypeText: strings.Split(flags, " "),
 		keys.TypeEnv:  os.Environ(),
+	}
+	k, err := keys.Get(keysType)
+	if err != nil {
+		log.Panic(err)
 	}
 
 	// use file, flags oe env
 	switch keysType {
 	case keys.TypeText, keys.TypeEnv:
 		keyFlags := k.Import(inputs[keysType], SecretTag)
+
 		// Encrypt all secrets that are not encrypted of each key
 		p := crypto.Providers[cryptoProvider]
 		for _, keyFlag := range keyFlags {

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -49,11 +49,15 @@ func encrypt(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Panic(err)
 	}
+	inputs := map[keys.Type][]string{
+		keys.TypeText: strings.Split(flags, " "),
+		keys.TypeEnv:  os.Environ(),
+	}
 
 	// use file, flags oe env
 	switch keysType {
-	case keys.TypeText:
-		keyFlags := k.Import(strings.Split(flags, " "), SecretTag)
+	case keys.TypeText, keys.TypeEnv:
+		keyFlags := k.Import(inputs[keysType], SecretTag)
 		// Encrypt all secrets that are not encrypted of each key
 		p := crypto.Providers[cryptoProvider]
 		for _, keyFlag := range keyFlags {
@@ -77,8 +81,6 @@ func encrypt(cmd *cobra.Command, args []string) {
 		if err := k.ReplaceOriginFile(file, values); err != nil {
 			log.Panic(err)
 		}
-	case keys.TypeEnv:
-		log.Panic("env type is not ready")
 	default:
 		log.Panicf("keysType does not support %s", keysType)
 	}

--- a/cmd/encrypt_test.go
+++ b/cmd/encrypt_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/17media/macgyver/cmd/keys"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type encryptTestSuite struct {
+	suite.Suite
+}
+
+func (s *encryptTestSuite) SetupSuite()    {}
+func (s *encryptTestSuite) TearDownSuite() {}
+func (s *encryptTestSuite) SetupTest()     {}
+func (s *encryptTestSuite) TearDownTest()  {}
+
+func (s *encryptTestSuite) TestEncrypt() {
+	s.Run("encrypt text base64", func() {
+		realStdout := os.Stdout
+		defer func() { os.Stdout = realStdout }()
+		r, fakeStdout, _ := os.Pipe()
+
+		cryptoProvider = "base64"
+		keysType = keys.TypeText
+		flags = "-test=test"
+		os.Stdout = fakeStdout
+
+		encrypt(encryptCmd, []string{})
+		_ = fakeStdout.Close()
+		newOutBytes, _ := ioutil.ReadAll(r)
+		s.Equal([]byte("-test=<SECRET_TAG>dGVzdA==</SECRET_TAG>\n"), newOutBytes)
+	})
+}
+
+func TestEncryptSuite(t *testing.T) {
+	suite.Run(t, new(encryptTestSuite))
+}

--- a/cmd/keys/file.go
+++ b/cmd/keys/file.go
@@ -1,0 +1,165 @@
+package keys
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+func parseYaml(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = parseYaml(v)
+		}
+		return m2
+	case []interface{}:
+		for i, v := range x {
+			x[i] = parseYaml(v)
+		}
+	}
+	return i
+}
+
+func convertYamlToMap(data []byte) map[string]interface{} {
+	var body interface{}
+	if err := yaml.Unmarshal(data, &body); err != nil {
+		panic(err)
+	}
+	body = parseYaml(body)
+	return body.(map[string]interface{})
+}
+
+func operationInMap(v interface{}, f func(path string) (interface{}, error)) (interface{}, error) {
+	merge := func(strMap map[string]interface{}, k string, v interface{}) (bool, error) {
+		switch v.(type) {
+		case map[string]interface{}, map[interface{}]interface{}:
+		default:
+			return false, nil
+		}
+
+		k2, err := operationInMap(k, f)
+		if err != nil {
+			return false, err
+		}
+		switch yamlOrJson := k2.(type) {
+		case string:
+			if yamlOrJson == k {
+				break
+			}
+			m := map[string]interface{}{}
+			if err := yaml.Unmarshal([]byte(yamlOrJson), &m); err != nil {
+				return false, err
+			}
+			for mk, mv := range m {
+				strMap[mk] = mv
+			}
+			return true, nil
+		}
+		return false, nil
+	}
+
+	var castedValue interface{}
+	switch typedValue := v.(type) {
+	case string:
+		return f(typedValue)
+	case map[interface{}]interface{}:
+		strMap := map[string]interface{}{}
+		for k, v := range typedValue {
+			strMap[fmt.Sprintf("%v", k)] = v
+		}
+		extends := map[string]interface{}{}
+		var deleted []string
+		for k, v := range strMap {
+			ok, err := merge(extends, k, v)
+			if ok {
+				deleted = append(deleted, k)
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			v2, err := operationInMap(v, f)
+			if err != nil {
+				return nil, err
+			}
+			strMap[k] = v2
+		}
+		for _, k := range deleted {
+			delete(strMap, k)
+		}
+		for k, v := range extends {
+			strMap[k] = v
+		}
+		return strMap, nil
+
+	case map[string]interface{}:
+		extends := map[string]interface{}{}
+		var deleted []string
+		for k, v := range typedValue {
+			ok, err := merge(extends, k, v)
+			if ok {
+				deleted = append(deleted, k)
+				continue
+			}
+
+			v2, err := operationInMap(v, f)
+			if err != nil {
+				return nil, err
+			}
+			typedValue[k] = v2
+		}
+		for _, k := range deleted {
+			delete(typedValue, k)
+		}
+		for k, v := range extends {
+			typedValue[k] = v
+		}
+		return typedValue, nil
+	case []interface{}:
+		var a []interface{}
+		for i := range typedValue {
+			res, err := operationInMap(typedValue[i], f)
+			if err != nil {
+				return nil, err
+			}
+			a = append(a, res)
+		}
+		castedValue = a
+	case []string:
+		var a []interface{}
+		for i := range typedValue {
+			res, err := f(typedValue[i])
+			if err != nil {
+				return nil, err
+			}
+			a = append(a, res)
+		}
+		castedValue = a
+	default:
+		castedValue = typedValue
+	}
+	return castedValue, nil
+}
+
+func RandomCreateFile(data []byte) (string, error) {
+	id, _ := uuid.NewUUID()
+	fileName := id.String()
+	file, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	defer file.Close()
+	if err != nil {
+		return "", err
+	}
+	if _, err := file.Write(data); err != nil {
+		return "", err
+	}
+	return fileName, nil
+}
+
+func RemoveFile(name string) error {
+	err := os.Remove(name)
+	return err
+}

--- a/cmd/keys/impl.go
+++ b/cmd/keys/impl.go
@@ -2,13 +2,14 @@ package keys
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/17media/macgyver/cmd/crypto"
 )

--- a/cmd/keys/impl.go
+++ b/cmd/keys/impl.go
@@ -26,7 +26,7 @@ type envsKeys struct {
 
 func (e *envsKeys) Import(input []string, secretTag string) []Key {
 	var ks []Key
-	envRegexp := `^(\w+)=(.+)$`
+	envRegexp := `^(\w+)=(.*)$`
 	reEnv := regexp.MustCompile(envRegexp)
 	reSecret := getSecretRegexp(secretTag)
 	for _, env := range input {

--- a/cmd/keys/impl.go
+++ b/cmd/keys/impl.go
@@ -1,8 +1,11 @@
 package keys
 
 import (
+	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"io"
+	"io/ioutil"
 	"log"
 	"regexp"
 	"strings"
@@ -12,6 +15,7 @@ var (
 	keys = map[Type]Keys{
 		TypeText: &flagsKeys{},
 		TypeEnv:  &envsKeys{},
+		TypeFile: &fileKeys{},
 	}
 )
 
@@ -80,6 +84,79 @@ func (f *flagsKeys) Export(keys []Key, secretTag string, writeCloser io.WriteClo
 		exportFlags += fmt.Sprintf(" -%s=%s", k.Key, newValue)
 	}
 	if _, err := writeCloser.Write([]byte(strings.TrimLeft(exportFlags, " ") + "\n")); err != nil {
+		return err
+	}
+	return writeCloser.Close()
+}
+
+func parseYaml(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = parseYaml(v)
+		}
+		return m2
+	case []interface{}:
+		for i, v := range x {
+			x[i] = parseYaml(v)
+		}
+	}
+	return i
+}
+
+func convertYamlToMap(data []byte) map[string]interface{} {
+	var body interface{}
+	if err := yaml.Unmarshal(data, &body); err != nil {
+		panic(err)
+	}
+	body = parseYaml(body)
+	// Test parse to JSON
+	if _, err := json.Marshal(body); err != nil {
+		panic(err)
+	}
+	return body.(map[string]interface{})
+}
+
+type fileKeys struct {
+}
+
+func (f *fileKeys) Import(input []string, secretTag string) []Key {
+	var ks []Key
+	reSecret := getSecretRegexp(secretTag)
+	rawData, err := ioutil.ReadFile(input[0])
+	if err != nil {
+		log.Panicf("ReadFile failed %s", err)
+	}
+	data := convertYamlToMap(rawData)
+	for key, value := range data {
+		switch v := value.(type) {
+		case string:
+			ks = append(ks, Key{
+				Key:     key,
+				Value:   v,
+				Secrets: reSecret.parseValueToSecrets(v),
+			})
+		case map[interface{}]interface{}:
+
+		case []interface{}:
+
+		default:
+
+		}
+	}
+	fmt.Println(ks)
+	return ks
+}
+
+func (f *fileKeys) Export(keys []Key, secretTag string, writeCloser io.WriteCloser) error {
+	exportStrs := ""
+	reSecret := getSecretRegexp(secretTag)
+	for _, k := range keys {
+		newValue := reSecret.replaceSecrets(k.Value, k.Secrets)
+		exportStrs += fmt.Sprintf("export %s='%s'\n", k.Key, newValue)
+	}
+	if _, err := writeCloser.Write([]byte(exportStrs)); err != nil {
 		return err
 	}
 	return writeCloser.Close()

--- a/cmd/keys/impl_test.go
+++ b/cmd/keys/impl_test.go
@@ -2,7 +2,9 @@ package keys
 
 import (
 	"bytes"
+	"github.com/17media/macgyver/cmd/crypto"
 	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -313,6 +315,210 @@ func (s *keysTestSuite) TestSecretRegexp() {
 		secrets := re.parseValueToSecrets(t.value)
 		s.Equal(t.expSecrets, secrets, "check parsed secrets", t.desc)
 		s.Equal(t.expNewValue, re.replaceSecrets(t.value, secrets), "check new value", t.desc)
+	}
+}
+
+func (s *keysTestSuite) TestFileKeysEncrypt() {
+	tests := []struct {
+		desc      string
+		input     []byte
+		metadata  map[string]interface{}
+		secretTag string
+		expOutput []byte
+	}{
+		{
+			desc: "test single",
+			input: []byte(`test: aa
+`),
+			metadata: map[string]interface{}{
+				"test": "<SECRET_TAG>YWE=</SECRET_TAG>",
+			},
+			secretTag: "secret_tag",
+			expOutput: []byte(
+				`test: <SECRET_TAG>YWE=</SECRET_TAG>
+`,
+			),
+		},
+		{
+			desc: "test nested struct and multi secrets",
+			input: []byte(
+				`test: 1
+test2:
+   abc: "aa "
+   c: true
+   d: 3.222
+   def: mongo://plaintext_userName:ciphertext_password@1.2.3.4:8080/production
+   test3:
+       e:
+           - aaa/
+           - 232
+           - 'dcsc: s'
+       f: asc
+       t: acc
+`,
+			),
+			metadata: map[string]interface{}{
+				"test": 1,
+				"test2": map[string]interface{}{
+					"abc": "<SECRET_TAG>YWEg</SECRET_TAG>",
+					"c":   true,
+					"d":   3.222,
+					"def": "<SECRET_TAG>bW9uZ286Ly9wbGFpbnRleHRfdXNlck5hbWU6Y2lwaGVydGV4dF9wYXNzd29yZEAxLjIuMy40OjgwODAvcHJvZHVjdGlvbg==</SECRET_TAG>",
+					"test3": map[string]interface{}{
+						"e": []interface{}{
+							"<SECRET_TAG>YWFhLw==</SECRET_TAG>",
+							232,
+							"<SECRET_TAG>ZGNzYzogcw==</SECRET_TAG>",
+						},
+						"f": "<SECRET_TAG>YXNj</SECRET_TAG>",
+						"t": "<SECRET_TAG>YWNj</SECRET_TAG>",
+					},
+				},
+			},
+			secretTag: "secret_tag",
+			expOutput: []byte(
+				`test: 1
+test2:
+    abc: <SECRET_TAG>YWEg</SECRET_TAG>
+    c: true
+    d: 3.222
+    def: <SECRET_TAG>bW9uZ286Ly9wbGFpbnRleHRfdXNlck5hbWU6Y2lwaGVydGV4dF9wYXNzd29yZEAxLjIuMy40OjgwODAvcHJvZHVjdGlvbg==</SECRET_TAG>
+    test3:
+        e:
+            - <SECRET_TAG>YWFhLw==</SECRET_TAG>
+            - 232
+            - <SECRET_TAG>ZGNzYzogcw==</SECRET_TAG>
+        f: <SECRET_TAG>YXNj</SECRET_TAG>
+        t: <SECRET_TAG>YWNj</SECRET_TAG>
+`,
+			),
+		},
+	}
+
+	fileKeys, err := Get(TypeFile)
+	crypto.Init("base64")
+	cp := crypto.Providers["base64"]
+	s.NoError(err)
+	for _, t := range tests {
+		s.Run(t.desc, func() {
+			fileName, err := RandomCreateFile(t.input)
+			s.NoError(err)
+
+			meta := fileKeys.Encrypt(fileName, t.secretTag, cp)
+			s.Equal(t.metadata, meta)
+
+			err = fileKeys.ReplaceOriginFile(fileName, meta)
+			s.NoError(err)
+
+			actOutput, err := ioutil.ReadFile(fileName)
+			s.NoError(err)
+			s.Equal(t.expOutput, actOutput)
+
+			err = RemoveFile(fileName)
+			s.NoError(err)
+		})
+	}
+}
+
+func (s *keysTestSuite) TestFileKeysDecrypt() {
+	tests := []struct {
+		desc      string
+		input     []byte
+		metadata  map[string]interface{}
+		secretTag string
+		expOutput []byte
+	}{
+		{
+			desc: "test single",
+			input: []byte(`test: <SECRET_TAG>YWEg</SECRET_TAG>
+`),
+			metadata: map[string]interface{}{
+				"test": "aa ",
+			},
+			secretTag: "secret_tag",
+			expOutput: []byte(
+				`test: 'aa '
+`,
+			),
+		},
+		{
+			desc: "test nested struct and multi secrets",
+			input: []byte(
+				`test: 1
+test2:
+   abc: <SECRET_TAG>YWE=</SECRET_TAG>
+   c: true
+   d: 3.222
+   def: <SECRET_TAG>bW9uZ286Ly9wbGFpbnRleHRfdXNlck5hbWU6Y2lwaGVydGV4dF9wYXNzd29yZEAxLjIuMy40OjgwODAvcHJvZHVjdGlvbg==</SECRET_TAG>
+   test3:
+       e:
+           - <SECRET_TAG>YWFhLw==</SECRET_TAG>
+           - 232
+           - <SECRET_TAG>ZGNzYzogcw==</SECRET_TAG>
+       f: <SECRET_TAG>YXNj</SECRET_TAG>
+       t: <SECRET_TAG>YWNj</SECRET_TAG>
+`,
+			),
+			metadata: map[string]interface{}{
+				"test": 1,
+				"test2": map[string]interface{}{
+					"abc": "aa",
+					"c":   true,
+					"d":   3.222,
+					"def": "mongo://plaintext_userName:ciphertext_password@1.2.3.4:8080/production",
+					"test3": map[string]interface{}{
+						"e": []interface{}{
+							"aaa/",
+							232,
+							"dcsc: s",
+						},
+						"f": "asc",
+						"t": "acc",
+					},
+				},
+			},
+			secretTag: "secret_tag",
+			expOutput: []byte(
+				`test: 1
+test2:
+    abc: aa
+    c: true
+    d: 3.222
+    def: mongo://plaintext_userName:ciphertext_password@1.2.3.4:8080/production
+    test3:
+        e:
+            - aaa/
+            - 232
+            - 'dcsc: s'
+        f: asc
+        t: acc
+`,
+			),
+		},
+	}
+
+	fileKeys, err := Get(TypeFile)
+	crypto.Init("base64")
+	cp := crypto.Providers["base64"]
+	s.NoError(err)
+	for _, t := range tests {
+		s.Run(t.desc, func() {
+			fileName, err := RandomCreateFile(t.input)
+			s.NoError(err)
+
+			meta := fileKeys.Decrypt(fileName, t.secretTag, cp)
+			s.Equal(t.metadata, meta)
+
+			err = fileKeys.ReplaceOriginFile(fileName, meta)
+			s.NoError(err)
+
+			actOutput, err := ioutil.ReadFile(fileName)
+			s.NoError(err)
+			s.Equal(t.expOutput, actOutput)
+
+			err = RemoveFile(fileName)
+			s.NoError(err)
+		})
 	}
 }
 

--- a/cmd/keys/impl_test.go
+++ b/cmd/keys/impl_test.go
@@ -2,12 +2,13 @@ package keys
 
 import (
 	"bytes"
-	"github.com/17media/macgyver/cmd/crypto"
 	"io"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/17media/macgyver/cmd/crypto"
 )
 
 type keysTestSuite struct {

--- a/cmd/keys/keys.go
+++ b/cmd/keys/keys.go
@@ -2,8 +2,9 @@ package keys
 
 import (
 	"fmt"
-	"github.com/17media/macgyver/cmd/crypto"
 	"io"
+
+	"github.com/17media/macgyver/cmd/crypto"
 )
 
 // Type of the Keys implemented Keys

--- a/cmd/keys/keys.go
+++ b/cmd/keys/keys.go
@@ -11,6 +11,7 @@ type Type string
 const (
 	TypeText Type = "text"
 	TypeEnv       = "env"
+	TypeFile      = "file"
 )
 
 // Get returns the Keys of a Type is exists

--- a/cmd/keys/keys.go
+++ b/cmd/keys/keys.go
@@ -2,6 +2,7 @@ package keys
 
 import (
 	"fmt"
+	"github.com/17media/macgyver/cmd/crypto"
 	"io"
 )
 
@@ -38,6 +39,8 @@ type Secret struct {
 
 // Keys defines keys operations
 type Keys interface {
+	// Import and Export are function for old env and flag keys
+
 	// Import parses the input into keys, the secrets of keys are parsed by secretTag.
 	// The regexp pattern of secrets is `<%s>(.*?)</%s>|<%s>(.*?)</%s>`. Only one group might be captured.
 	// If no secretTag is captured, the entire value of the key will be regarded as a plaintext secret. (i.e. Secret{Text:"Value of the Key", IsEncrypted: false})
@@ -53,4 +56,19 @@ type Keys interface {
 	// If `secret.IsEncrypted` is false, the secret will be the `secret.Text` only.
 	// If `secret.IsEncrypted` is true, the secret will be the <secretTag>secret.Text</secretTag>.
 	Export(keys []Key, secretTag string, writeCloser io.WriteCloser) error
+
+	// Encrypt Decrypt and ReplaceOrignalFile are for file type key
+	// Encrypt and Decrypt parses the target file into map struct and decrypt/encrypt directly
+	// Because there will be nested data in file type while we use JSON/YAML, it's wasteful to use original way (Import to []Key then decrypt/encrypt) to encrypt/decrypt.
+	// It will use DFS to find out string to do the target function, so we prevent it to run it twice.
+	// inputs:
+	//     input: filePath
+	//     secretTag: secretTag
+	//     cp: crypto Provider instance
+	// outputs:
+	//     file data in map struct after encrypt/decrypt
+	Encrypt(input string, secretTag string, cp crypto.Crypto) map[string]interface{}
+	Decrypt(input string, secretTag string, cp crypto.Crypto) map[string]interface{}
+
+	ReplaceOriginFile(input string, values map[string]interface{}) error
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	cryptoProvider string
 	oAuthLocation  string
 	flags          string
+	file           string
 	keysType       keys.Type
 	SecretTag      string
 	GCPprojectID   string
@@ -102,6 +103,10 @@ func init() {
 	// var AWSprofileName string
 	RootCmd.PersistentFlags().StringVar(&AWSprofileName, "AWSprofileName", "", "the profile name used for AWS authentication")
 	viper.BindPFlag("AWSprofileName", RootCmd.PersistentFlags().Lookup("AWSprofileName"))
+
+	// var file string
+	RootCmd.PersistentFlags().StringVar(&file, "file", "", "file want to decrypt/encrypt")
+	viper.BindPFlag("file", RootCmd.PersistentFlags().Lookup("file"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,7 @@ func init() {
 	viper.BindPFlag("cryptoProvider", RootCmd.PersistentFlags().Lookup("cryptoProvider"))
 
 	// var keysType string
-	RootCmd.PersistentFlags().StringVar((*string)(&keysType), "keysType", "text", "Which input type you using for encrypto and encryto")
+	RootCmd.PersistentFlags().StringVar((*string)(&keysType), "keysType", "text", "Which input type you using for encrypto and encryto (e.g. text, file and env)")
 	viper.BindPFlag("keysType", RootCmd.PersistentFlags().Lookup("keysType"))
 
 	// var SecretTag string
@@ -105,7 +105,7 @@ func init() {
 	viper.BindPFlag("AWSprofileName", RootCmd.PersistentFlags().Lookup("AWSprofileName"))
 
 	// var file string
-	RootCmd.PersistentFlags().StringVar(&file, "file", "", "file want to decrypt/encrypt")
+	RootCmd.PersistentFlags().StringVar(&file, "file", "", "absolute filepath for a yaml you want to decrypt/encrypt")
 	viper.BindPFlag("file", RootCmd.PersistentFlags().Lookup("file"))
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ func init() {
 	viper.BindPFlag("GCPcryptoKeyID", RootCmd.PersistentFlags().Lookup("GCPcryptoKeyID"))
 
 	// var AWSlocationID string
-	RootCmd.PersistentFlags().StringVar(&AWSlocationID, "AWSlocationID", "", "the cryptoKeyID of AWS")
+	RootCmd.PersistentFlags().StringVar(&AWSlocationID, "AWSlocationID", "", "the locationID of AWS")
 	viper.BindPFlag("AWSlocationID", RootCmd.PersistentFlags().Lookup("AWSlocationID"))
 
 	// var AWScryptoKeyID string


### PR DESCRIPTION
1. Make macgyver support YAML encrypt/decrypt.
2. Fix base64 decrypt with padding. (e.g. "aa" → YWE= → "aa\0")
3. Fix envType error while env is empty (e.g. TEST= ).