### PR TITLE
set macgyver build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: ## install go modules
 
 .PHONY: build
 build: ## build go binary
-	@go build -o macgyver main.go
+	@tag="$(shell git tag -l --points-at HEAD)"; go build -ldflags="-X 'main.version=$$tag'" -o macgyver main.go
 	@tar zcvf macgyver.tar.gz macgyver
 
 # Ubuntu Only

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -15,6 +16,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Macgyver",
 	Long:  `All software has versions. This is Macgyver's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v1.1.1")
+		fmt.Println(viper.GetString("version"))
 	},
 }

--- a/main.go
+++ b/main.go
@@ -5,11 +5,16 @@ import (
 	"os"
 
 	"github.com/17media/macgyver/cmd"
+	"github.com/spf13/viper"
 )
 
+var version = "dev"
+
 func main() {
+	viper.SetDefault("version", version)
+
 	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
+	    fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description
version.go 的版本原本是寫死的 `fmt.Println("v1.1.1")`，改成在 build binary 的時候下 tag



## Note

`-ldflags` 的 package path  本來想下 `-ldflags="-X 'cmd.version=$$tag'"`
但不知道為什麼不行，只好放在 main